### PR TITLE
Fix UTF-8 codepoint split by FormatterWriter

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,17 +9,32 @@ pub struct FormatterWriter<'a, 'b: 'a>(pub &'a mut fmt::Formatter<'b>);
 
 impl<'a, 'b: 'a> io::Write for FormatterWriter<'a, 'b> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match str::from_utf8(buf) {
-            Ok(buf_str) => self
-                .0
-                .write_str(buf_str)
-                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
-                .map(|()| buf.len()),
-            Err(err) => Err(io::Error::new(io::ErrorKind::InvalidData, err)),
+        let buf_str = match str::from_utf8(buf) {
+            Ok(buf_str) => buf_str,
+            // SAFETY: str::from_utf8() certifies that a part of the string is valid UTF-8.
+            Err(err) => unsafe { str::from_utf8_unchecked(&buf[0..err.valid_up_to()]) },
+        };
+        match self.0.write_str(buf_str) {
+            Ok(()) => Ok(buf_str.len()),
+            Err(err) => Err(io::Error::new(io::ErrorKind::Other, err)),
         }
     }
 
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::JSON;
+    use std::fmt::Write;
+
+    #[test]
+    fn format_unicode() {
+        let mut output = String::new();
+        write!(&mut output, "{}", JSON("🤨🤨\n😮😮\n🤨🤨\n😮😮OMG"))
+            .expect("no formatting errors");
+        assert_eq!(output, r#""🤨🤨\n😮😮\n🤨🤨\n😮😮OMG""#);
     }
 }


### PR DESCRIPTION
`FormatterWriter` has to deal with an inherent conflict: `fmt::Formatter` wants to write &str values (required to be valid UTF-8) while `io::Write` can be used to write arbitrary byte slices. This causes `JSON` helper to fail with certain non-ASCII strings.

SIMD-optimized JSON string formatting can cause writes that split UTF-8 codepoints, causing `str::from_utf8()` to fail since the input buffer for FormatterWriter has a chunk of UTF-8 codepoint at the end.

Consider the string from the new test:

    "🤨🤨\n😮😮\n🤨🤨\n😮😮OMG"

which is encoded and processed like this:

     F0 9F A4 A8 F0 9F A4 A8 0A F0 9F 98 AE F0 9F 98 AE 0A F0 9F A4 A8 F0 9F A4 A8 0A F0 9F 98 AE F0 9F 98 AE 4F 4D 47   UTF-8 string

    |           |           |  |           |           |  |           |           |  |           |           |  |  |  |  UTF-8 codepoint boundaries
                                            -----------                                           -----------
    |                                               |                                               |                    i128 boundaries

In order to deal with it, `FormatterWriter` can write only the part which *is* valid UTF-8, keeping `fmt::Formatter` happy. `io::Write` allows partial write but its users have to be ready for that. Teach `write_json_simd()` to be ready by accounting how many bytes have been written, and if `write_json_nosimd_prevalidated()` doesn't write everything then the suffix gets written on the next call.

Benchmarks don't reveal any change in performance caused by that extra byte counting.